### PR TITLE
Add better error capture and error message for invliad multiprocess targets

### DIFF
--- a/docs/src/docs/UserGuide/BasicConcepts.md
+++ b/docs/src/docs/UserGuide/BasicConcepts.md
@@ -19,23 +19,24 @@ Pyper follows the [functional paradigm](https://docs.python.org/3/howto/function
 * Python functions are the building blocks used to create `Pipeline` objects
 * `Pipeline` objects can themselves be thought of as functions
 
-For example, to create a simple pipeline, we can wrap a function in the `task` decorator:
+For example, to create a simple pipeline, we can wrap a function in the `task` class:
 
 ```python
 from pyper import task
 
-@task
 def len_strings(x: str, y: str) -> int:
     return len(x) + len(y)
+
+pipeline = task(len_strings)
 ```
 
-This defines `len_strings` as a pipeline consisting of a single task. It takes the parameters `(x: str, y: str)` and generates `int` outputs from an output queue:
+This defines `pipeline` as a pipeline consisting of a single task. It takes the parameters `(x: str, y: str)` and generates `int` outputs from an output queue:
 
 <img src="../../assets/img/diagram1.png" alt="Diagram" style="height: 250px; width: auto;">
 
 **Key Concepts**
 
-* A <b style="color:#3399FF;">pipeline</b> is a functional reprentation of data-flow _(Pyper API)_
+* A <b style="color:#3399FF;">Pipeline</b> is a representation of data-flow _(Pyper API)_
 * A **task** represents a single functional operation within a pipeline _(user defined)_
 * Under the hood, tasks pass data along via <b style="color:#FF8000;">workers</b> and <b style="color:#FF8000;">queues</b> _(Pyper internal)_
 
@@ -45,21 +46,22 @@ Pipelines are composable components; to create a pipeline which runs multiple ta
 import time
 from pyper import task
 
-@task
 def len_strings(x: str, y: str) -> int:
     return len(x) + len(y)
 
-@task(workers=3)
 def sleep(data: int) -> int:
     time.sleep(data)
     return data
 
-@task(workers=2)
 def calculate(data: int) -> bool:
     time.sleep(data)
     return data % 2 == 0
 
-pipeline = len_strings | sleep | calculate
+pipeline = (
+    task(len_strings) 
+    | task(sleep, workers=3)
+    | task(calculate, workers=2)
+)
 ```
 
 This defines `pipeline` as a series of tasks, taking the parameters `(x: str, y: str)` and generating `bool` outputs:

--- a/docs/src/docs/UserGuide/CreatingPipelines.md
+++ b/docs/src/docs/UserGuide/CreatingPipelines.md
@@ -19,25 +19,15 @@ Pyper's `task` decorator is the means by which we instantiate pipelines and cont
 ```python
 from pyper import task, Pipeline
 
-@task
-def func(x: int):
-    return x + 1
-
-assert isinstance(func, Pipeline)
-```
-
-This creates a `Pipeline` object consisting of one 'task' (one step of data transformation). 
-
-The `task` decorator can also be used more dynamically, which is preferable in most cases as this separates execution logic from the functional definitions themselves:
-
-```python
-from pyper import task
-
 def func(x: int):
     return x + 1
 
 pipeline = task(func)
+
+assert isinstance(pipeline, Pipeline)
 ```
+
+This creates a `Pipeline` object consisting of one 'task' (one step of data transformation). 
 
 In addition to functions, anything `callable` in Python can be wrapped in `task` in the same way:
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -74,11 +74,29 @@ def test_raise_for_invalid_func():
     else:
         raise AssertionError
 
-def test_raise_for_invalid_multiprocess():
+def test_raise_for_async_multiprocess():
     try:
         task(afunc, multiprocess=True)
     except Exception as e:
         assert isinstance(e, ValueError)
+    else:
+        raise AssertionError
+
+def test_raise_for_lambda_multiprocess():
+    try:
+        task(lambda x: x, multiprocess=True)
+    except Exception as e:
+        assert isinstance(e, RuntimeError)
+    else:
+        raise AssertionError
+    
+def test_raise_for_non_global_multiprocess():
+    try:
+        @task(multiprocess=True)
+        def f(x):
+            return x
+    except Exception as e:
+        assert isinstance(e, RuntimeError)
     else:
         raise AssertionError
 


### PR DESCRIPTION
Functions decorated with `task` using @-syntax cannot be multiprocessed.

- Add a helpful error message for cases where the user tries to multiprocess any non-globally-accessible function
- Update the docs to encourage the dynamic usage of `task`