### PR TITLE
docs: fix function name typo in `task.md`

### DIFF
--- a/docs/src/docs/ApiReference/task.md
+++ b/docs/src/docs/ApiReference/task.md
@@ -195,7 +195,7 @@ def slow_consumer(data: int):
     return data
 
 pipeline = (
-    task(fast_consumer, branch=True, throttle=5000)
+    task(fast_producer, branch=True, throttle=5000)
     | task(slow_consumer)
 )
 ```


### PR DESCRIPTION
`fast_consumer` should be `fast_producer` in the throttle section of the task API reference